### PR TITLE
Fix typo in window resize listener

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -18,7 +18,7 @@ const Hero = () => {
     window.addEventListener('resize', handleVideoSrcSet);
 
     return () => {
-      window.removeEventListener('reisze', handleVideoSrcSet)
+      window.removeEventListener('resize', handleVideoSrcSet)
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- remove the listener with the correct `resize` event in `Hero.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68400aed6aec8330b5be8a053b4921ea